### PR TITLE
Raise log level for sync complete message

### DIFF
--- a/shadowGroupSync.ps1
+++ b/shadowGroupSync.ps1
@@ -275,5 +275,5 @@ foreach ($cs in $csv)
     }
   }
   
-  Write-Verbose "$($cs.GroupName) sync complete."
+  Write "$($cs.GroupName) sync complete."
 }


### PR DESCRIPTION
Logging level should not need to be verbose to generate a log file with completion messages
