### PR TITLE
PowerShell v4 requires $multiobj to be declared first

### DIFF
--- a/shadowGroupSync.ps1
+++ b/shadowGroupSync.ps1
@@ -51,6 +51,7 @@ Import-Module ActiveDirectory -ErrorAction Stop
 #        Example: 0 or "Base", 1 or "OneLevel", 2 or "SubTree"
 Function Get-SourceObjects($searchbase, $domain, $type, $scope)
 {
+  $multiobj = @()
   $obj = $null
   $bases = $searchbase.Split(";")
 


### PR DESCRIPTION
Hi,

I recently moved this script from a machine using PowerShell v3 to v4 and it threw an error (below). I think the fix is to declare the multiobj array now, otherwise it tries to add ADUser objects together and they do not support the addition operator. It should work with all versions of PowerShell (I've not tested it though).

Thanks,

Ian
```
Method invocation failed because [Microsoft.ActiveDirectory.Management.ADUser] does not contain a method named
'op_Addition'.
At C:\Betgenius\DevOps\ActiveDirectory\ShadowGroupSync\shadowGroupSync.ps1:62 char:7
+       $multiobj += Get-SourceObjects $base $domain $type $scope
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (op_Addition:String) [], RuntimeException
    + FullyQualifiedErrorId : MethodNotFound
```